### PR TITLE
First raw implementation using StdIn parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # `hidi`: Command line tool to obfuscate AWS files of any sort
 
+
+## Usage:
+```bash
+go run . < original.txt > scrambled.txt 
+```
+
 ## Why?
 
 I need a tool that allows me to safely publish any data coming from an AWS

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rsora/hidi
+
+go 1.18

--- a/main.go
+++ b/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bufio"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Comes from https://stackoverflow.com/a/38915828
+// tested with:
+// - Ec2 Instances like i-b9b4ffaa
+// - AMI like ami-dbcf88b1
+// - Volumes like vol-e97db305
+const awsIDRegex = "(?i)\\b[a-z]+-[a-z0-9]+"
+
+func main() {
+	// Let's set a random salt for tis command execution
+	rand.Seed(time.Now().UnixNano())
+	salt := fmt.Sprint(rand.Intn(100))
+
+	// Start reding Std in
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Println(Scramble(scanner.Text(), salt))
+	}
+
+	if err := scanner.Err(); err != nil {
+		panic(err)
+	}
+}
+
+// Scramble scans a line of text and replaces all the aws ids with new ones
+// keeping their uniqueness characteristics using md5 + salt approach.
+// the salt is generated for each run of the command in order to keep the
+// 1:1 correspondence between ids in the passed file
+func Scramble(line, salt string) string {
+	r, _ := regexp.Compile(awsIDRegex)
+	ids := r.FindAllString(line, -1)
+	scrambledLine := line
+	for _, id := range ids {
+		// A generic AWS resource id like "vol-e97db305"
+		// is composed by [resourceType]-[hexSuffix]:
+		// resourceType = "vol"
+		// hexSuffix = "e97db305"
+		resourceType := strings.Split(id, "-")[0]
+		hexSuffix := strings.Split(id, "-")[1]
+		hexSuffixLen := len(hexSuffix)
+		md5 := GetMD5Hash(hexSuffix + salt)
+		// cut the salted MD5 to the same length as the original hexSuffix
+		hexSuffixScrambled := string(md5[0:hexSuffixLen])
+		scrambledId := strings.Join([]string{resourceType, hexSuffixScrambled}, "-")
+		scrambledLine = strings.Replace(scrambledLine, id, scrambledId, -1)
+	}
+
+	return scrambledLine
+}
+
+// GetMD5Hash returns md5 hash of the passed string
+// in a string format containing an hex number
+func GetMD5Hash(text string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
+}


### PR DESCRIPTION
## What
This PR adds a first implementation of the scrambler

## How
Scrambling process goes the following:
1. find an AWS id using random regex copypasted from stack overflow :smile_cat: 
2. scan file line by line to find AWS ids
3. if found, calculate a salted MD5 of the hex suffix for the id, the salt is always the same for the entire command run, this way uniqueness is maintained inside the file
4. truncate the salted MD% to match the original suffix length
5. replace the original id with the salted MD5 one in the entire row
6. repeat for all the ids found in the row
7. print the scrambled line
8. repeat for all lines

## Additional info
Tested manually with a small number of id types:
- Ec2 Instances like `i-b9b4ffaa`
- AMI like `ami-dbcf88b1`
- Volumes like `vol-e97db305`