### PR TITLE
Add Scrambling of AWS Account number / AWS Account IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+original.txt
+scrambled.txt

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 // - Ec2 Instances like i-b9b4ffaa
 // - AMI like ami-dbcf88b1
 // - Volumes like vol-e97db305
-const awsIDRegex = "(?i)\\b[a-z]+-[a-z0-9]+"
+const awsIDRegex = "(?i)\\b[a-z]+-[a-z0-9]{8,}"
 
 func main() {
 	// Let's set a random salt for tis command execution

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"regexp"
@@ -18,6 +19,7 @@ import (
 // - AMI like ami-dbcf88b1
 // - Volumes like vol-e97db305
 const awsIDRegex = "(?i)\\b[a-z]+-[a-z0-9]{8,}"
+const awsAccountIDRegex = "\\b[0-9]{12}"
 
 func main() {
 	// Let's set a random salt for tis command execution
@@ -27,7 +29,10 @@ func main() {
 	// Start reding Std in
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		fmt.Println(Scramble(scanner.Text(), salt))
+		line := scanner.Text()
+		line = ScrambleAWSResourceID(line, salt)
+		line = ScrambleAWSAccountID(line, salt)
+		fmt.Println(line)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -35,11 +40,11 @@ func main() {
 	}
 }
 
-// Scramble scans a line of text and replaces all the aws ids with new ones
+// ScrambleAWSResourceID scans a line of text and replaces all the aws ids with new ones
 // keeping their uniqueness characteristics using md5 + salt approach.
 // the salt is generated for each run of the command in order to keep the
 // 1:1 correspondence between ids in the passed file
-func Scramble(line, salt string) string {
+func ScrambleAWSResourceID(line, salt string) string {
 	r, _ := regexp.Compile(awsIDRegex)
 	ids := r.FindAllString(line, -1)
 	scrambledLine := line
@@ -50,11 +55,26 @@ func Scramble(line, salt string) string {
 		// hexSuffix = "e97db305"
 		resourceType := strings.Split(id, "-")[0]
 		hexSuffix := strings.Split(id, "-")[1]
-		hexSuffixLen := len(hexSuffix)
 		md5 := GetMD5Hash(hexSuffix + salt)
 		// cut the salted MD5 to the same length as the original hexSuffix
-		hexSuffixScrambled := string(md5[0:hexSuffixLen])
+		hexSuffixScrambled := string(md5[0:len(hexSuffix)])
 		scrambledId := strings.Join([]string{resourceType, hexSuffixScrambled}, "-")
+		scrambledLine = strings.Replace(scrambledLine, id, scrambledId, -1)
+	}
+
+	return scrambledLine
+}
+
+// ScrambleAWSAccountID scrambles AWS account id
+func ScrambleAWSAccountID(line, salt string) string {
+	r, _ := regexp.Compile(awsAccountIDRegex)
+	ids := r.FindAllString(line, -1)
+	scrambledLine := line
+	for _, id := range ids {
+		md5 := GetMD5Hash(id + salt)
+		bi := big.NewInt(0)
+		bi.SetString(md5, 16)
+		scrambledId := bi.String()[0:len(id)]
 		scrambledLine = strings.Replace(scrambledLine, id, scrambledId, -1)
 	}
 


### PR DESCRIPTION
## What
This PR adds scrambling support also for aws account ids i.e. 12 digits numbers like `736906108532`

## How
Scrambling is doneusing same `GetMD5Hash(id + salt)` approach, and then converting to a string of numbers truncating to the len of the original id