### PR TITLE
Skip odd hex suffixes for AWS resource ids

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,13 @@ func ScrambleAWSResourceID(line, salt string) string {
 		// hexSuffix = "e97db305"
 		resourceType := strings.Split(id, "-")[0]
 		hexSuffix := strings.Split(id, "-")[1]
+		// hexSuffix for a real aws res id
+		// must have an even number of chars to be an hex number.
+		// I know, this could be checked with a more complex regex
+		// but it will end up being not so clear to read
+		if len(hexSuffix)%2 != 0 {
+			continue
+		}
 		md5 := GetMD5Hash(hexSuffix + salt)
 		// cut the salted MD5 to the same length as the original hexSuffix
 		hexSuffixScrambled := string(md5[0:len(hexSuffix)])


### PR DESCRIPTION
What
Refine AWS resource id regex adding a guard that skips generation of scrambled id if `hexSuffix` has an odd number of chars

Why
same reason as #3: I use in my serverless projects a "kebab" style for naming resources like `sls-statuses` that can match with the original regex