### PR TITLE
Add -s flag to pass custom salt to hasing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # `hidi`: Command line tool to obfuscate AWS files of any sort
 
-
 ## Usage:
+
 ```bash
-go run . < original.txt > scrambled.txt 
+go run . [-s <your-salt-string>] < original.txt > scrambled.txt
 ```
+
+The `-s` flag contains the salt that will be passed to hash functions that
+scramble the aws ids. This variable will be exposed as flag to allow to keep the
+same salt on multiple command runs allowing to have multiple files that remains
+with same ids if scrambled with the same salt (think about having multiple
+billing files for the same aws account or multiple placebo files for the same
+test session)
 
 ## Why?
 
@@ -41,5 +48,3 @@ the rest of the world.
 The idea is to have a brute file parser that scans files line by line applying
 heuristics (probably regexes) to find sensitive data and scramble it,
 maintaining it compatible with AWS standards.
-
-

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/md5"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -21,10 +22,22 @@ import (
 const awsIDRegex = "(?i)\\b[a-z]+-[0-9a-f]{8,}"
 const awsAccountIDRegex = "\\b[0-9]{12}"
 
+// salt contains the salt that will be passed to hash functions
+// that scramble the aws ids. this variable will be exposed as flag
+// to allow to keep the same salt on multiple command runs
+// allowing to have multiple files that remains with same ids if
+// scrambled with the same salt
+// (think about having multiple billing files for the same aws account or
+// multiple placebo files for the same test session)
+var salt string
+
 func main() {
-	// Let's set a random salt for tis command execution
+	// Let's set a default random salt for this command execution
 	rand.Seed(time.Now().UnixNano())
-	salt := fmt.Sprint(rand.Intn(100))
+	defaultSalt := fmt.Sprint(rand.Intn(100))
+
+	flag.StringVar(&salt, "s", defaultSalt, "(s)alt passed to aws ids scramble functions")
+	flag.Parse()
 
 	// Start reding Std in
 	scanner := bufio.NewScanner(os.Stdin)


### PR DESCRIPTION
## Why
The `-s` flag contains the salt that will be passed to hash functions that scramble the aws ids. 
This variable will be exposed as flag to allow to keep the same salt on multiple command runs allowing to have multiple files that remains with same ids if scrambled with the same salt (think about having multiple billing files for the same aws account or multiple placebo files for the same test session)

## How
Added simple `-s` flag to allow launch:
```bash
go run . [-s <your-salt-string>] < original.txt > scrambled.txt
```
If no `-s` flag is passed, a random salt is generated