### PR TITLE
Add parameter to allow custom replacement in for target:replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 ```bash
 go run . [-s <your-salt-string>] < original.txt > scrambled.txt
+
+Flags:
+  -c value
+        (c)ustom replace keyword in the form target:replacement
+  -s string
+        (s)alt passed to aws ids scramble functions (default "14")
 ```
 
 The `-s` flag contains the salt that will be passed to hash functions that

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const awsAccountIDRegex = "\\b[0-9]{12}\\b"
 type arrayFlags []string
 
 func (i *arrayFlags) String() string {
-	return fmt.Sprint(i)
+	return ""
 }
 
 func (i *arrayFlags) Set(value string) error {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,19 @@ import (
 const awsIDRegex = "(?i)\\b([a-z]+-[0-9a-f]{17}|[a-z]+-[0-9a-f]{8})\\b"
 const awsAccountIDRegex = "\\b[0-9]{12}\\b"
 
+// arrayFlags allows me to pass multiple values for the same flag like
+// command -opt first -opt second
+type arrayFlags []string
+
+func (i *arrayFlags) String() string {
+	return fmt.Sprint(i)
+}
+
+func (i *arrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 // salt contains the salt that will be passed to hash functions
 // that scramble the aws ids. this variable will be exposed as flag
 // to allow to keep the same salt on multiple command runs
@@ -32,12 +45,15 @@ const awsAccountIDRegex = "\\b[0-9]{12}\\b"
 // multiple placebo files for the same test session)
 var salt string
 
+var customReplaceKeywords arrayFlags
+
 func main() {
 	// Let's set a default random salt for this command execution
 	rand.Seed(time.Now().UnixNano())
 	defaultSalt := fmt.Sprint(rand.Intn(100))
 
 	flag.StringVar(&salt, "s", defaultSalt, "(s)alt passed to aws ids scramble functions")
+	flag.Var(&customReplaceKeywords, "c", "(c)ustom replace keyword in the form target:replacement")
 	flag.Parse()
 
 	// Start reding Std in
@@ -46,6 +62,7 @@ func main() {
 		line := scanner.Text()
 		line = ScrambleAWSResourceID(line, salt)
 		line = ScrambleAWSAccountID(line, salt)
+		line = ReplaceCustomStrings(line, customReplaceKeywords)
 		fmt.Println(line)
 	}
 
@@ -102,4 +119,16 @@ func GetMD5Hash(text string) string {
 	hasher := md5.New()
 	hasher.Write([]byte(text))
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// ReplaceCustomStrings expects custom replace strings to be in form target:replacement
+// if parsing goes wrong, no replacement is applied
+func ReplaceCustomStrings(line string, customReplaceKeywords arrayFlags) string {
+	cleanedLine := line
+	for _, k := range customReplaceKeywords {
+		target := strings.Split(k, ":")[0]
+		replacement := strings.Split(k, ":")[1]
+		cleanedLine = strings.Replace(cleanedLine, target, replacement, -1)
+	}
+	return cleanedLine
 }


### PR DESCRIPTION
## Why
In case you need to replace a sensible application name or company name from the input file, you can now add multiple `-c` params to replace them with a string of your choice:

```bash 
$ hidi < original.txt > scrambled.txt  -c microsoft:acme -c apache:nginx

```

this `hidi` run is going to replace all occurrences of `microsoft` with `acme` and all occurrences of `apache` with `nginx`